### PR TITLE
Fix host parsing

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -28,11 +28,9 @@ host = ARGUMENTS.get('host', '')
 
 if host != '':
     parts = host.split('-')
-    if len(parts) is not 4:
-        print("Malformed host identifier, expected 4 items '{0}'".format(host))
-        sys.exit(2)
 
-    platform = parts[2]
+    # The platform identifier is always the second to last part of the host string (which can be 3 or 4 items long)
+    platform = parts[len(parts) - 2]
     CXX = '{0}-g++'.format(host)
 else:
     try:


### PR DESCRIPTION
The code was asserting that a host identifier string must be 4 parts,
but this is not the case.  Make the parsing code work with 3 or 4 item
host identifiers.

Signed-off-by: Eric B Munson <eric@cobaltspeech.com>